### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -20,9 +20,9 @@ getThetaDotX	KEYWORD2
 getThetaDotY	KEYWORD2
 getThetaDotZ	KEYWORD2
 getEncoderLeft	KEYWORD2
-getEncoderRight KEYWORD2
-getOdometryLeft KEYWORD2
-getOdometryRight KEYWORD2
+getEncoderRight	KEYWORD2
+getOdometryLeft	KEYWORD2
+getOdometryRight	KEYWORD2
 resetEncoderLeft	KEYWORD2
 resetEncoderRight	KEYWORD2
 setMotorLeft	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords